### PR TITLE
Could not install ../grunt-maketextfiles/

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "grunt-makeTextFiles",
+  "name": "grunt-maketextfiles",
   "description": "Builds textfiles.js needed by eDetails",
   "version": "0.1.2",
   "homepage": "",
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/incuna/grunt-makeTextFiles"
+    "url": "git://github.com/incuna/grunt-maketextfiles"
   },
   "bugs": {
     "url": ""


### PR DESCRIPTION
npm erros when I try to install:

> Could not install ../grunt-maketextfiles/
> npm ERR! Error: Invalid name: "grunt-makeTextFiles"

It works if I update the name in package.json to be `grunt-maketextfiles` - all lowercase
