### PR TITLE
Fix existing filepath check always returning true and adding path.

### DIFF
--- a/tasks/makeTextFiles.js
+++ b/tasks/makeTextFiles.js
@@ -115,7 +115,7 @@ module.exports = function(grunt) {
 
                 //populate lists for template
                 _(matchingFiles).each(function(filePath) {
-                    if (!filePaths[filePath]) {
+                    if (!_.contains(filePaths, filePath)) {
                         //dont add if we already have the paths in the list
                         //this allows overriding of paths by the project
                         var requireBasePath = 'text!';


### PR DESCRIPTION
Stop trying to access the filePaths array as an object, thus returning a
falsey value (arrays don't have enumarable non-numerical properties) and so
always added the filePath to the filePaths array. This meant that a template
in project/ will never override the same template from a library.

@incuna/js Please merge, ta!
